### PR TITLE
JSON-RPC 2.0 Parameter Structures

### DIFF
--- a/AFJSONRPCClient/AFJSONRPCClient.h
+++ b/AFJSONRPCClient/AFJSONRPCClient.h
@@ -54,7 +54,7 @@
  
  */
 - (void)invokeMethod:(NSString *)method
-      withParameters:(NSArray *)parameters
+      withParameters:(id)parameters
              success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
              failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 
@@ -62,7 +62,7 @@
  
  */
 - (void)invokeMethod:(NSString *)method
-      withParameters:(NSArray *)parameters
+      withParameters:(id)parameters
            requestId:(id)requestId
              success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
              failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
@@ -71,7 +71,7 @@
  
  */
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method
-                                parameters:(NSArray *)parameters
+                                parameters:(id)parameters
                                  requestId:(id)requestId;
 
 

--- a/AFJSONRPCClient/AFJSONRPCClient.m
+++ b/AFJSONRPCClient/AFJSONRPCClient.m
@@ -67,7 +67,7 @@ NSString * const AFJSONRPCErrorDomain = @"com.alamofire.networking.json-rpc";
 }
 
 - (void)invokeMethod:(NSString *)method
-      withParameters:(NSArray *)parameters
+      withParameters:(id)parameters
              success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
              failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
 {
@@ -75,7 +75,7 @@ NSString * const AFJSONRPCErrorDomain = @"com.alamofire.networking.json-rpc";
 }
 
 - (void)invokeMethod:(NSString *)method
-      withParameters:(NSArray *)parameters
+      withParameters:(id)parameters
            requestId:(id)requestId
              success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
              failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
@@ -86,7 +86,7 @@ NSString * const AFJSONRPCErrorDomain = @"com.alamofire.networking.json-rpc";
 }
 
 - (NSMutableURLRequest *)requestWithMethod:(NSString *)method
-                                parameters:(NSArray *)parameters
+                                parameters:(id)parameters
                                  requestId:(id)requestId
 {
     NSParameterAssert(method);
@@ -94,6 +94,8 @@ NSString * const AFJSONRPCErrorDomain = @"com.alamofire.networking.json-rpc";
     if (!parameters) {
         parameters = [NSArray array];
     }
+
+    NSAssert([parameters isKindOfClass:[NSDictionary class]] || [parameters isKindOfClass:[NSArray class]]);
 
     if (!requestId) {
         requestId = [NSNumber numberWithInteger:1];

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AFJSONRPCClient *client = [AFJSONRPCClient clientWithEndpointURL:[NSURL URLWithS
 
 // Invocation with Parameters
 [client invokeWithMethod:@"method.name" 
-              parameters:@[@"foo", @"bar", @"baz"] 
+              parameters:@{@"foo" : @"bar", @"baz" : @(13)}
     success:^(AFHTTPRequestOperation *operation, id responseObject) {
     // ...
 }   failure:^(AFHTTPRequestOperation *operation, NSError *error) {

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ MyJSONRPCClient *client = [MyJSONRPCClient sharedClient];
 
 ## Installation
 
-[CocoaPods](http://cocoapods.org) is the recommended way to add AFIncrementalStore to your project.
+[CocoaPods](http://cocoapods.org) is the recommended way to add AFJSONRPCClient to your project.
 
-Here's an example podfile that installs AFIncrementalStore and its dependency, AFNetworking. 
+Here's an example podfile that installs AFJSONRPCClient and its dependency, AFNetworking. 
 
 ### Podfile
 


### PR DESCRIPTION
According to [JSON-RPC 2.0 Specification](http://www.jsonrpc.org/specification) (4.2 Parameter Structures), one can use _by-name_ parameters. This is something pretty common. Changed a few lines to support this. Also fixed a typo in README.md.
