### PR TITLE
Fix deprecation warning

### DIFF
--- a/AFJSONRPCClient/AFJSONRPCClient.m
+++ b/AFJSONRPCClient/AFJSONRPCClient.m
@@ -111,7 +111,7 @@ NSString * const AFJSONRPCErrorDomain = @"com.alamofire.networking.json-rpc";
     payload[@"params"] = parameters;
     payload[@"id"] = [requestId description];
 
-    return [self.requestSerializer requestWithMethod:@"POST" URLString:[self.endpointURL absoluteString] parameters:payload];
+    return [self.requestSerializer requestWithMethod:@"POST" URLString:[self.endpointURL absoluteString] parameters:payload error:nil];
 }
 
 #pragma mark - AFHTTPClient

--- a/AFJSONRPCClient/AFJSONRPCClient.m
+++ b/AFJSONRPCClient/AFJSONRPCClient.m
@@ -111,7 +111,14 @@ NSString * const AFJSONRPCErrorDomain = @"com.alamofire.networking.json-rpc";
     payload[@"params"] = parameters;
     payload[@"id"] = [requestId description];
 
-    return [self.requestSerializer requestWithMethod:@"POST" URLString:[self.endpointURL absoluteString] parameters:payload error:nil];
+    if ([self.requestSerializer respondsToSelector:@selector(requestWithMethod:URLString:parameters:error:)]) {
+        return [self.requestSerializer requestWithMethod:@"POST" URLString:[self.endpointURL absoluteString] parameters:payload error:nil];
+    } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        return [self.requestSerializer requestWithMethod:@"POST" URLString:[self.endpointURL absoluteString] parameters:payload];
+#pragma clang diagnostic pop
+    }
 }
 
 #pragma mark - AFHTTPClient


### PR DESCRIPTION
Don't use the deprecated 

```
- (NSMutableURLRequest *)requestWithMethod:(NSString *)method URLString:(NSString *)URLString  parameters:(id)parameters DEPRECATED_ATTRIBUTE;
```

Instead use 

```
- (NSMutableURLRequest *)requestWithMethod:(NSString *)method URLString:(NSString *)URLString  parameters:(id)parameters error:(NSError * __autoreleasing *)error;
```
