### PR TITLE
Return after executing success block

### DIFF
--- a/AFJSONRPCClient/AFJSONRPCClient.m
+++ b/AFJSONRPCClient/AFJSONRPCClient.m
@@ -149,6 +149,7 @@ static NSString * AFJSONRPCLocalizedErrorMessageForCode(NSInteger code) {
             if (result && result != [NSNull null]) {
                 if (success) {
                     success(operation, result);
+                    return;
                 }
             } else if (error && error != [NSNull null]) {
                 if ([error isKindOfClass:[NSDictionary class]]) {


### PR DESCRIPTION
This prevents an additional, unwanted execution of the failure block after the success block is executed.
