### PR TITLE
Adding the possibility to explicitly omit the the request-id 

### DIFF
--- a/AFJSONRPCClient/AFJSONRPCClient.m
+++ b/AFJSONRPCClient/AFJSONRPCClient.m
@@ -126,7 +126,10 @@ static NSString * AFJSONRPCLocalizedErrorMessageForCode(NSInteger code) {
     payload[@"jsonrpc"] = @"2.0";
     payload[@"method"] = method;
     payload[@"params"] = parameters;
-    payload[@"id"] = [requestId description];
+    
+    if (requestId != [NSNull null]) {
+        payload[@"id"] = [requestId description];
+    }
 
     return [self.requestSerializer requestWithMethod:@"POST" URLString:[self.endpointURL absoluteString] parameters:payload error:nil];
 }


### PR DESCRIPTION
In some cases it would be useful to explicitly omit the `id` param from a JSON-RPC request.

The [JSON-RPC specification](http://www.jsonrpc.org/specification#conventions) defines a request without the `id` member as the special "Notification" request type (see 4.1). 

I guess the easiest way to do this, is to allow passing `NSNull` as the `requestId`. In that case, the request would explicitly not contain the `id` field. Using `NSNull` for that, allows also to keep the current default, where the id gets set to '1' if `nil` was passed.
