### PR TITLE
Compatibility with AFNetworking 3 and HTTP/2

### DIFF
--- a/AFJSONRPCClient.podspec
+++ b/AFJSONRPCClient.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'
 
-  s.dependency 'AFNetworking', '~> 2.1'
+  s.dependency 'AFNetworking', '> 2.1'
 end

--- a/AFJSONRPCClient.podspec
+++ b/AFJSONRPCClient.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 
-  s.dependency 'AFNetworking', '> 2.1'
+  s.dependency 'AFNetworking', '~> 3.0'
 end

--- a/AFJSONRPCClient.podspec
+++ b/AFJSONRPCClient.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'
   s.watchos.deployment_target = '2.0'
+  s.tvos.deployment_target = '9.0'
 
   s.dependency 'AFNetworking', '> 2.1'
 end

--- a/AFJSONRPCClient.podspec
+++ b/AFJSONRPCClient.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source_files = 'AFJSONRPCClient'
   s.requires_arc = true
 
-  s.ios.deployment_target = '6.0'
+  s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.8'
 
   s.dependency 'AFNetworking', '~> 2.1'

--- a/AFJSONRPCClient.podspec
+++ b/AFJSONRPCClient.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.8'
+  s.osx.deployment_target = '10.9'
 
   s.dependency 'AFNetworking', '~> 2.1'
 end

--- a/AFJSONRPCClient.podspec
+++ b/AFJSONRPCClient.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'
+  s.watchos.deployment_target = '2.0'
 
   s.dependency 'AFNetworking', '> 2.1'
 end

--- a/AFJSONRPCClient/AFJSONRPCClient.h
+++ b/AFJSONRPCClient/AFJSONRPCClient.h
@@ -21,14 +21,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFHTTPRequestOperationManager.h"
+#import "AFHTTPSessionManager.h"
 
 /**
  AFJSONRPCClient objects communicate with web services using the JSON-RPC 2.0 protocol.
  
  @see http://www.jsonrpc.org/specification
  */
-@interface AFJSONRPCClient : AFHTTPRequestOperationManager
+@interface AFJSONRPCClient : AFHTTPSessionManager
 
 /**
  The endpoint URL for the webservice.
@@ -74,8 +74,8 @@
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a two arguments: the request operation and the error describing the network or parsing error that occurred.
  */
 - (void)invokeMethod:(NSString *)method
-             success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
-             failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+             success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+             failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure;
 
 /**
  Creates a request with the specified method and parameters, and enqueues a request operation for it.
@@ -87,8 +87,8 @@
  */
 - (void)invokeMethod:(NSString *)method
       withParameters:(id)parameters
-             success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
-             failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+             success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+             failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure;
 
 /**
  Creates a request with the specified method and parameters, and enqueues a request operation for it.
@@ -102,8 +102,8 @@
 - (void)invokeMethod:(NSString *)method
       withParameters:(id)parameters
            requestId:(id)requestId
-             success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
-             failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+             success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+             failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure;
 
 ///----------------------
 /// @name Method Proxying

--- a/AFJSONRPCClient/AFJSONRPCClient.h
+++ b/AFJSONRPCClient/AFJSONRPCClient.h
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFHTTPSessionManager.h"
+#import <AFNetworking/AFHTTPSessionManager.h>
 
 /**
  AFJSONRPCClient objects communicate with web services using the JSON-RPC 2.0 protocol.

--- a/AFJSONRPCClient/AFJSONRPCClient.m
+++ b/AFJSONRPCClient/AFJSONRPCClient.m
@@ -22,8 +22,6 @@
 // THE SOFTWARE.
 
 #import "AFJSONRPCClient.h"
-#import "AFHTTPRequestOperation.h"
-
 #import <objc/runtime.h>
 
 NSString * const AFJSONRPCErrorDomain = @"com.alamofire.networking.json-rpc";
@@ -81,16 +79,16 @@ static NSString * AFJSONRPCLocalizedErrorMessageForCode(NSInteger code) {
 }
 
 - (void)invokeMethod:(NSString *)method
-             success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
-             failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+             success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+             failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
 {
     [self invokeMethod:method withParameters:@[] success:success failure:failure];
 }
 
 - (void)invokeMethod:(NSString *)method
       withParameters:(id)parameters
-             success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
-             failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+             success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+             failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
 {
     [self invokeMethod:method withParameters:parameters requestId:@(1) success:success failure:failure];
 }
@@ -98,17 +96,8 @@ static NSString * AFJSONRPCLocalizedErrorMessageForCode(NSInteger code) {
 - (void)invokeMethod:(NSString *)method
       withParameters:(id)parameters
            requestId:(id)requestId
-             success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
-             failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
-{
-    NSMutableURLRequest *request = [self requestWithMethod:method parameters:parameters requestId:requestId];
-    AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
-    [self.operationQueue addOperation:operation];
-}
-
-- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
-                                parameters:(id)parameters
-                                 requestId:(id)requestId
+             success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+             failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
 {
     NSParameterAssert(method);
 
@@ -127,17 +116,8 @@ static NSString * AFJSONRPCLocalizedErrorMessageForCode(NSInteger code) {
     payload[@"method"] = method;
     payload[@"params"] = parameters;
     payload[@"id"] = [requestId description];
-
-    return [self.requestSerializer requestWithMethod:@"POST" URLString:[self.endpointURL absoluteString] parameters:payload error:nil];
-}
-
-#pragma mark - AFHTTPClient
-
-- (AFHTTPRequestOperation *)HTTPRequestOperationWithRequest:(NSURLRequest *)urlRequest
-                                                    success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
-                                                    failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
-{
-    return [super HTTPRequestOperationWithRequest:urlRequest success:^(AFHTTPRequestOperation *operation, id responseObject) {
+    
+    [self POST:@"" parameters:payload success:^(NSURLSessionDataTask * _Nonnull task, id  _Nonnull responseObject) {
         NSInteger code = 0;
         NSString *message = nil;
         id data = nil;
@@ -148,7 +128,7 @@ static NSString * AFJSONRPCLocalizedErrorMessageForCode(NSInteger code) {
 
             if (result && result != [NSNull null]) {
                 if (success) {
-                    success(operation, result);
+                    success(task, result);
                     return;
                 }
             } else if (error && error != [NSNull null]) {
@@ -185,12 +165,13 @@ static NSString * AFJSONRPCLocalizedErrorMessageForCode(NSInteger code) {
             }
 
             NSError *error = [NSError errorWithDomain:AFJSONRPCErrorDomain code:code userInfo:userInfo];
-
-            failure(operation, error);
+            
+            failure(task, error);
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        
+    } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
         if (failure) {
-            failure(operation, error);
+            failure(task, error);
         }
     }];
 }
@@ -253,11 +234,11 @@ typedef void (^AFJSONRPCProxyFailureBlock)(NSError *error);
     __strong AFJSONRPCProxySuccessBlock strongSuccess = [unsafeSuccess copy];
     __strong AFJSONRPCProxyFailureBlock strongFailure = [unsafeFailure copy];
 
-    [self.client invokeMethod:RPCMethod withParameters:arguments success:^(__unused AFHTTPRequestOperation *operation, id responseObject) {
+    [self.client invokeMethod:RPCMethod withParameters:arguments success:^(__unused NSURLSessionDataTask *task, id responseObject) {
         if (strongSuccess) {
             strongSuccess(responseObject);
         }
-    } failure:^(__unused AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(__unused NSURLSessionDataTask *task, NSError *error) {
         if (strongFailure) {
             strongFailure(error);
         }


### PR DESCRIPTION
Using AFHTTPSessionManager instead of AFHTTPRequestOperation so that we can use AFJSONRPCClient with AFNetworking 3 and send JSON-RPC request over HTTP/2
